### PR TITLE
fix: add windows-11-arm prebuilt binary

### DIFF
--- a/.github/workflows/neon.yml
+++ b/.github/workflows/neon.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, macos-15-intel, ubuntu-latest]
+        os: [windows-latest, windows-11-arm, macos-latest, macos-15-intel, ubuntu-latest]
         node-version: [20, 22, 24, 25]
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Adds the GitHub-hosted `windows-11-arm` runner to the prebuild matrix in `.github/workflows/neon.yml` so the next tagged release produces `node-v{abi}-win32-arm64.tar.gz` artifacts for Node 20, 22, 24, and 25.

## Why

Windows ARM64 consumers currently fall back to building from source on `npm install` / `bun install` because no `win32-arm64` prebuilt exists in our releases — only `win32-x64`. Building from source requires Rust + MSVC arm64 toolchain, which isn't present on most developer machines or CI images.

Hit concretely while testing `@bugsplat/symbol-upload`'s new `bun build --compile` path on Windows ARM: Bun 1.3.13 reports Node ABI 137 (`process.versions.modules === "137"`), `@mapbox/node-pre-gyp` looks for `node-v137-win32-arm64.tar.gz`, and the download 404s.

## Test plan

- [x] Tag a release (or manually dispatch a workflow run against this branch) and confirm the matrix produces both `node-v{abi}-win32-x64.tar.gz` and `node-v{abi}-win32-arm64.tar.gz` for each supported Node version.
- [x] From a Windows ARM64 machine running Node 24 (ABI 137), `npm install node-dump-syms` should download the prebuilt rather than attempting `npm run build:client`.
- [x] Same check under Bun 1.3.13 on Windows ARM64.

## Notes / risks

- Assumes `windows-11-arm` images come with Rust + MSVC arm64 toolchain available (they do for the standard GitHub-hosted image), and that `actions/setup-node@v4` has ARM64 builds for Node 20+. If either is missing for a specific Node version, that single matrix cell will fail — the other cells (including existing x64 prebuilds) are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)